### PR TITLE
Fix inter-version compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export default function legacyDecoratorCompat(
           path.insertBefore(
             t.staticBlock([
               t.expressionStatement(
-                t.callExpression(state.runtime(path, "f"), args)
+                t.callExpression(state.runtime(path, "g"), args)
               ),
             ])
           );
@@ -206,7 +206,7 @@ export default function legacyDecoratorCompat(
           path.insertAfter(
             t.staticBlock([
               t.expressionStatement(
-                t.callExpression(state.runtime(path, "m"), [
+                t.callExpression(state.runtime(path, "n"), [
                   prototype,
                   valueForFieldKey(t, path.node.key),
                   t.arrayExpression(

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -50,8 +50,18 @@ function findDeferredDecorator(
   }
 }
 
-// decorateField
+// decorateField v1
 export function f(
+  target: { prototype: object },
+  prop: string | number | symbol,
+  decorators: LegacyDecorator[],
+  initializer?: () => any
+): void {
+  return g(target.prototype, prop, decorators, initializer);
+}
+
+// decorateField v2
+export function g(
   prototype: object,
   prop: string | number | symbol,
   decorators: LegacyDecorator[],
@@ -76,8 +86,17 @@ export function f(
   }
 }
 
-// decorateMethod
+// decorateMethod v1
 export function m(
+  { prototype }: { prototype: object },
+  prop: string | number | symbol,
+  decorators: LegacyDecorator[]
+): void {
+  return n(prototype, prop, decorators);
+}
+
+// decorateMethod v2
+export function n(
   prototype: object,
   prop: string | number | symbol,
   decorators: LegacyDecorator[]


### PR DESCRIPTION
It would be good if all 1.x versions of decorator-transforms can intermix the transform and the runtime. 1.0.2 accidentally didn't do that by making a breaking change to the contract between them.

This restores the two old methods, which are only one-liners on top of the new methods.

Fixes https://github.com/ef4/decorator-transforms/issues/9