### PR TITLE
fix collisions with existing private names

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/core": "^7.23.3",
     "@babel/plugin-proposal-decorators": "^7.23.3",
     "@babel/plugin-transform-class-properties": "^7.23.3",
+    "@babel/plugin-transform-private-methods": "^7.23.3",
     "@swc-node/register": "^1.6.8",
     "@types/babel__core": "^7.20.4",
     "@types/node": "^20.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ devDependencies:
   '@babel/plugin-transform-class-properties':
     specifier: ^7.23.3
     version: 7.23.3(@babel/core@7.23.3)
+  '@babel/plugin-transform-private-methods':
+    specifier: ^7.23.3
+    version: 7.23.3(@babel/core@7.23.3)
   '@swc-node/register':
     specifier: ^1.6.8
     version: 1.6.8(@swc/core@1.3.96)(typescript@5.2.2)
@@ -277,6 +280,17 @@ packages:
 
   /@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.3
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.3)
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.23.3):
+    resolution: {integrity: sha512-UzqRcRtWsDMTLrRWFvUBDwmw06tCQH9Rl1uAjfh6ijMSmGYQ+fpdB+cnqRC8EMh5tuuxSv0/TejGL+7vyj+50g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export default function legacyDecoratorCompat(
           state.currentClassBodies.unshift(path.node);
         },
         exit(_path, state) {
-          state.currentClassBodies.pop();
+          state.currentClassBodies.shift();
         },
       },
       ClassExpression(path, state) {
@@ -247,7 +247,7 @@ function unusedPrivateNameLike(state: State, name: string): string {
     }
   }
   let candidate = name;
-  while (usedNames.has("#" + candidate)) {
+  while (usedNames.has(candidate)) {
     candidate = candidate + "_";
   }
   return candidate;

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,6 +3,8 @@ import { transform, TransformOptions } from "@babel/core";
 import legacyDecorators from "@babel/plugin-proposal-decorators";
 // @ts-expect-error no upstream types
 import classProperties from "@babel/plugin-transform-class-properties";
+// @ts-expect-error no upstream types
+import classPrivateMethods from "@babel/plugin-transform-private-methods";
 
 import * as vm from "node:vm";
 import ourDecorators, { Options } from "../src/index.ts";
@@ -73,6 +75,7 @@ export interface Builder {
 export const oldBuild: Builder = builder([
   [legacyDecorators, { legacy: true }],
   classProperties,
+  classPrivateMethods,
 ]);
 
 let globalOpts: Options = { runtime: "globals" };


### PR DESCRIPTION
The collision detection for existing private names wasn't being tested property and didn't actually work correctly. This adds test coverage and fixes two bugs.
 - babel is giving us names with the `#` already stripped
 - the stack of current class bodies was pairing `unshift` with `pop` instead of `unshift` with `shift`.