### PR TITLE
Replace static blocks with private static field initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Example Config:
 }
 ```
 
+### staticBlock
+
+The `staticBlock` option controls how `decorator-transforms` outputs static class blocks:
+
+- `"native"` (_default_) will output native `static { }` blocks ([caniuse](https://caniuse.com/mdn-javascript_classes_static_initialization_blocks))
+- `"fields"` will shim the same functionality using private static class fields. These have slightly wider browser support. ([caniuse](https://caniuse.com/?search=static%20class%20fields))
+
 ## Trying this in an Ember App
 
 1. Install the `decorator-transforms` package.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ interface State extends Babel.PluginPass {
     decorated: [
       "field" | "method",
       t.Expression, // for the property name
-      t.Expression[], // for the decorators applied to it
+      t.Expression[] // for the decorators applied to it
     ][];
   }[];
   opts: Options;
@@ -22,6 +22,7 @@ interface State extends Babel.PluginPass {
 
 export interface Options {
   runtime?: "globals" | { import: string };
+  staticBlock?: "native" | "field";
 }
 
 export default function legacyDecoratorCompat(
@@ -37,6 +38,7 @@ export default function legacyDecoratorCompat(
         state.currentObjectExpressions = [];
         state.optsWithDefaults = {
           runtime: "globals",
+          staticBlock: "native",
           ...state.opts,
         };
         let importUtil = new ImportUtil(t, path);
@@ -172,18 +174,11 @@ export default function legacyDecoratorCompat(
             );
           }
           path.insertBefore(
-            t.classPrivateProperty(
-              t.privateName(
-                t.identifier(
-                  unusedPrivateNameLike(state, propName(path.node.key))
-                )
-              ),
-              t.sequenceExpression([
-                t.callExpression(state.runtime(path, "g"), args),
-                t.identifier("void 0"),
-              ]),
-              null,
-              true
+            compatStaticBlock(
+              state,
+              t,
+              path.node.key,
+              t.callExpression(state.runtime(path, "g"), args)
             )
           );
           path.insertBefore(
@@ -220,27 +215,20 @@ export default function legacyDecoratorCompat(
             );
           }
           path.insertAfter(
-            t.classPrivateProperty(
-              t.privateName(
-                t.identifier(
-                  unusedPrivateNameLike(state, propName(path.node.key))
-                )
-              ),
-              t.sequenceExpression([
-                t.callExpression(state.runtime(path, "n"), [
-                  prototype,
-                  valueForFieldKey(t, path.node.key),
-                  t.arrayExpression(
-                    decorators
-                      .slice()
-                      .reverse()
-                      .map((d) => d.node.expression)
-                  ),
-                ]),
-                t.identifier("void 0"),
-              ]),
-              null,
-              true
+            compatStaticBlock(
+              state,
+              t,
+              path.node.key,
+              t.callExpression(state.runtime(path, "n"), [
+                prototype,
+                valueForFieldKey(t, path.node.key),
+                t.arrayExpression(
+                  decorators
+                    .slice()
+                    .reverse()
+                    .map((d) => d.node.expression)
+                ),
+              ])
             )
           );
           for (let decorator of decorators) {
@@ -379,4 +367,23 @@ function valueForFieldKey(
     return t.stringLiteral(expr.name);
   }
   return expr;
+}
+
+// create a static block or a private class field depending on the staticBlock option
+function compatStaticBlock(
+  state: State,
+  t: (typeof Babel)["types"],
+  key: t.Expression,
+  expression: t.Expression
+) {
+  if (state.optsWithDefaults.staticBlock === "native") {
+    return t.staticBlock([t.expressionStatement(expression)]);
+  } else {
+    return t.classPrivateProperty(
+      t.privateName(t.identifier(unusedPrivateNameLike(state, propName(key)))),
+      expression,
+      null,
+      true
+    );
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,11 +172,19 @@ export default function legacyDecoratorCompat(
             );
           }
           path.insertBefore(
-            t.staticBlock([
-              t.expressionStatement(
-                t.callExpression(state.runtime(path, "g"), args)
+            t.classPrivateProperty(
+              t.privateName(
+                t.identifier(
+                  unusedPrivateNameLike(state, propName(path.node.key))
+                )
               ),
-            ])
+              t.sequenceExpression([
+                t.callExpression(state.runtime(path, "g"), args),
+                t.identifier("void 0"),
+              ]),
+              null,
+              true
+            )
           );
           path.insertBefore(
             t.classPrivateProperty(
@@ -212,8 +220,13 @@ export default function legacyDecoratorCompat(
             );
           }
           path.insertAfter(
-            t.staticBlock([
-              t.expressionStatement(
+            t.classPrivateProperty(
+              t.privateName(
+                t.identifier(
+                  unusedPrivateNameLike(state, propName(path.node.key))
+                )
+              ),
+              t.sequenceExpression([
                 t.callExpression(state.runtime(path, "n"), [
                   prototype,
                   valueForFieldKey(t, path.node.key),
@@ -223,9 +236,12 @@ export default function legacyDecoratorCompat(
                       .reverse()
                       .map((d) => d.node.expression)
                   ),
-                ])
-              ),
-            ])
+                ]),
+                t.identifier("void 0"),
+              ]),
+              null,
+              true
+            )
           );
           for (let decorator of decorators) {
             decorator.remove();

--- a/tests/class-test.ts
+++ b/tests/class-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from "qunit";
-import { oldBuild, newBuild, Builder } from "./helpers.ts";
+import { oldBuild, newBuild, Builder, compatNewBuild } from "./helpers.ts";
 import { type LegacyClassDecorator } from "../src/runtime.ts";
 import * as runtimeImpl from "../src/runtime.ts";
 import { globalId } from "../src/global-id.ts";
@@ -200,3 +200,4 @@ function classTests(title: string, build: Builder) {
 
 classTests("old-build", oldBuild);
 classTests("new-build", newBuild);
+classTests("compat-new-build", compatNewBuild);

--- a/tests/compat-test.ts
+++ b/tests/compat-test.ts
@@ -1,0 +1,26 @@
+import { module, test } from "qunit";
+import { newBuild, compatNewBuild } from "./helpers.ts";
+
+module(`Compat`, () => {
+  test("uses real static blocks when staticBlocks: native", (assert) => {
+    const transformedSrc = newBuild.transformSrc(
+      `
+        class Example {
+          @withColors myField;
+        }
+        `
+    );
+    assert.true(transformedSrc.includes("static {"));
+  });
+
+  test("uses private static class fields when staticBlocks: fields", (assert) => {
+    const transformedSrc = compatNewBuild.transformSrc(
+      `
+        class Example {
+          @withColors myField;
+        }
+        `
+    );
+    assert.false(transformedSrc.includes("static {"));
+  });
+});

--- a/tests/field-test.ts
+++ b/tests/field-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from "qunit";
-import { oldBuild, newBuild, Builder } from "./helpers.ts";
+import { oldBuild, newBuild, Builder, compatNewBuild } from "./helpers.ts";
 import { type LegacyDecorator } from "../src/runtime.ts";
 import * as runtimeImpl from "../src/runtime.ts";
 import { globalId } from "../src/global-id.ts";
@@ -417,3 +417,4 @@ function fieldTests(title: string, build: Builder) {
 }
 fieldTests("old-build", oldBuild);
 fieldTests("new-build", newBuild);
+fieldTests("compat-new-build", compatNewBuild);

--- a/tests/method-test.ts
+++ b/tests/method-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from "qunit";
-import { oldBuild, newBuild, Builder } from "./helpers.ts";
+import { oldBuild, newBuild, Builder, compatNewBuild } from "./helpers.ts";
 import { type LegacyDecorator } from "../src/runtime.ts";
 import * as runtimeImpl from "../src/runtime.ts";
 import { globalId } from "../src/global-id.ts";
@@ -220,3 +220,4 @@ function methodTests(title: string, build: Builder) {
 
 methodTests("old-build", oldBuild);
 methodTests("new-build", newBuild);
+methodTests("compat-new-build", compatNewBuild);


### PR DESCRIPTION
Private static field initializers offer the same timing as class static blocks, while offering better browser support. For example, private static field initializers are supported on Safari >= 14.5 while static blocks are only supported in Safari >= 16.4.

Given this input:

```js
class MyClass {
  @myDecorator
  decoratedField = 'field value';

  @myDecorator
  decoratedMethod() {
    return 'method response';
  }
}
```

This commit changes the output from:

```js
class MyClass {
  static {
    dt7948.g(this.prototype, "decoratedField", [myDecorator], function () {
      return 'field value';
    });
  }
  #decoratedField = (dt7948.i(this, "decoratedField"), void 0);
  decoratedMethod() {
    return 'method response';
  }
  static {
    dt7948.n(this.prototype, "decoratedMethod", [myDecorator]);
  }
}
```

to this:

```js
class MyClass {
  static #decoratedField = (dt7948.g(this.prototype, "decoratedField", [myDecorator], function () {
    return 'field value';
  }), void 0);
  #decoratedField_ = (dt7948.i(this, "decoratedField"), void 0);
  decoratedMethod() {
    return 'method response2';
  }
  static #decoratedMethod = (dt7948.n(this.prototype, "decoratedMethod", [myDecorator]), void 0);
}
```

Resolves #3