### PR TITLE
Mutate existing default export declarations for improved compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,9 +108,9 @@ export default function legacyDecoratorCompat(
               path.parentPath.insertBefore(
                 t.variableDeclaration("const", [t.variableDeclarator(id, call)])
               );
-              path.parentPath.replaceWith(t.exportDefaultDeclaration(id));
+              path.parentPath.node.declaration = id;
             } else {
-              path.parentPath.replaceWith(t.exportDefaultDeclaration(call));
+              path.parentPath.node.declaration = call;
             }
           } else if (path.parentPath.isExportNamedDeclaration()) {
             let id = path.node.id;


### PR DESCRIPTION
Calling `t.exportDefaultDeclaration` triggers the `ExportDefaultDeclaration` in other babel transforms. In some cases triggering that hook multiple times can lead to unexpected behavior.

For example, in the the template-colocation-plugin at https://github.com/embroider-build/embroider/blob/289f83d80d/packages/shared-internals/src/template-colocation-plugin.ts), the first call of the hook will see a class declaration and set `state.associate`[^1] (which later causes `setComponentTemplate` to be appended after the `export` [^2]). The second call of the hook sees a non-class expression and wraps it in `setComponentTemplate` within the export [^3]. In the end, that leaves us with two `setComponentTemplate` calls.

[^1]: https://github.com/embroider-build/embroider/blob/289f83d80d/packages/shared-internals/src/template-colocation-plugin.ts#L103-L111
[^2]: https://github.com/embroider-build/embroider/blob/289f83d80d/packages/shared-internals/src/template-colocation-plugin.ts#L82-L91
[^3]: https://github.com/embroider-build/embroider/blob/289f83d80d/packages/shared-internals/src/template-colocation-plugin.ts#L129-L131


---
Resolves #16


This issue could alternatively be fixed with a change to the template-colocation-plugin itself (e.g. have it unset `state.associate` on the second invocation of `ExportDefaultDeclaration`.

I'm unsure how to go about adding a test for this. Do we want to try and pull the template-colocation-plugin into the decorator-transforms test suite somehow? 🤔 