### PR TITLE
Offer an explicit import path for esm vs cjs runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
       "import": "./dist/runtime.js",
       "require": "./dist/runtime.cjs"
     },
+    "./runtime-esm": "./dist/runtime.js",
+    "./runtime-cjs": "./dist/runtime.cjs",
     "./globals": {
       "import": "./dist/globals.js",
       "require": "./dist/globals.cjs"


### PR DESCRIPTION
When you want to ensure that you're talking about the esm distribution of the runtime, you can now use `decorator-transforms/runtime-esm`. (Ditto for cjs.)

This makes it easier to resolve the path to the esm runtime in a babel config that's itself written in cjs.