### PR TITLE
Fix unbalanced exit

### DIFF
--- a/tests/plugin-interop-test.ts
+++ b/tests/plugin-interop-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from "qunit";
-import { builder, Builder } from "./helpers.ts";
+import { builder } from "./helpers.ts";
 import { type LegacyClassDecorator } from "../src/runtime.ts";
 import * as runtimeImpl from "../src/runtime.ts";
 import ourDecorators from "../src/index.ts";
@@ -7,17 +7,16 @@ import { createRequire } from "node:module";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import type * as Babel from "@babel/core";
 
 const require = createRequire(import.meta.url);
 const Colocation = require("@embroider/shared-internals/src/template-colocation-plugin");
 
-module("plugin-interop", (hooks) => {
-  let build: Builder;
-
-  hooks.before(async () => {
+module("plugin-interop", () => {
+  test("colocation", async (assert) => {
     let dir = await mkdtemp(join(tmpdir(), "decorator-transforms-"));
     await writeFile(join(dir, "example.hbs"), "");
-    build = builder(
+    let build = builder(
       [],
       [
         [
@@ -29,9 +28,6 @@ module("plugin-interop", (hooks) => {
       [],
       join(dir, "example.js")
     );
-  });
-
-  test("colocation", async (assert) => {
     let red: LegacyClassDecorator = (target) => {
       return class extends target {
         get red() {
@@ -76,5 +72,54 @@ module("plugin-interop", (hooks) => {
 
     assert.strictEqual(new Example().red, "#ff0000");
     assert.strictEqual(setComponents, 1);
+  });
+
+  // This models a behavior that @embroider/macros uses when trying to optimize
+  // `getConfig().with.a.path`, since it uses parentPath to go higher and
+  // replace a larger part of the expression.
+  test("parentPath replace", async (assert) => {
+    function inserter(babel: typeof Babel): Babel.PluginObj {
+      let t = babel.types;
+      return {
+        visitor: {
+          CallExpression: {
+            enter(path) {
+              let callee = path.node.callee;
+              if (callee.type === "Identifier" && callee.name === "expandMe") {
+                path.parentPath.replaceWith(
+                  t.objectExpression([
+                    t.objectProperty(
+                      t.identifier("value"),
+                      t.stringLiteral("it worked")
+                    ),
+                  ])
+                );
+              }
+            },
+          },
+        },
+      };
+    }
+
+    let build = builder(
+      [],
+      [
+        [
+          ourDecorators,
+          { runtime: { import: "decorator-transforms/runtime" } },
+        ],
+        [inserter],
+      ],
+      []
+    );
+
+    let { default: Example } = await build.module(
+      `
+        export default expandMe().a;
+      `,
+      {}
+    );
+
+    assert.strictEqual(Example.value, "it worked");
   });
 });


### PR DESCRIPTION
If another babel plugin does `path.parentPath.replaceWith(...)`, it can cause us to see an `exit` for a new path that we never saw `enter`.