### PR TITLE
Revert "Don't use nodeisms"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import type * as Babel from '@babel/core';
 import type { types as t, NodePath } from '@babel/core';
+import { createRequire } from 'node:module';
 import { ImportUtil, type Importer } from 'babel-import-util';
 import { globalId } from './global-id.ts';
-
-// TS can't find declarations for this package (there aren't any)
-// @ts-ignore
-import { default as decoratorSyntax } from '@babel/plugin-syntax-decorators';
+const req = createRequire(import.meta.url);
+const { default: decoratorSyntax } = req('@babel/plugin-syntax-decorators');
 
 interface State extends Babel.PluginPass {
   currentClassBodies: t.ClassBody[];


### PR DESCRIPTION
This reverts commit a15f40eb10b2cbb18595bcf94f6308a1c4d63626.

It breaks, see https://github.com/ef4/decorator-transforms/pull/43