### PR TITLE
Fix: inherited field attributes not available for children

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -49,7 +49,7 @@ function findDeferredDecorator(
     if (desc) {
       return desc;
     }
-    cursor = (cursor as any).prototype;
+    cursor = Object.getPrototypeOf(cursor);
   }
 }
 

--- a/tests/field-test.ts
+++ b/tests/field-test.ts
@@ -413,6 +413,83 @@ function fieldTests(title: string, build: Builder) {
       });
       assert.strictEqual(example.value, 8);
     });
+
+    test('subclass inherits deferred field initializer from parent', (assert) => {
+      let noop: LegacyDecorator = function (_target, _prop, desc) {
+        return desc;
+      };
+
+      let Parent = build.expression(
+        `
+        class Parent {
+          @noop value = 'parent-value';
+        }
+        `,
+        { noop, ...runtime },
+      );
+
+      let Child = build.expression(
+        `
+        class Child extends Parent {
+          @noop other = 'child-value';
+        }
+        `,
+        { noop, Parent, ...runtime },
+      );
+
+      let child = new Child();
+      assert.strictEqual(
+        child.value,
+        'parent-value',
+        'child inherits parent decorated field',
+      );
+      assert.strictEqual(
+        child.other,
+        'child-value',
+        'child has own decorated field',
+      );
+
+      let parent = new Parent();
+      assert.strictEqual(parent.value, 'parent-value', 'parent field exists');
+    });
+
+    test('subclass inherits deferred field initializer through multiple levels', (assert) => {
+      let noop: LegacyDecorator = function (_target, _prop, desc) {
+        return desc;
+      };
+
+      let GrandParent = build.expression(
+        `
+        class GrandParent {
+          @noop a = 'grandparent';
+        }
+        `,
+        { noop, ...runtime },
+      );
+
+      let Parent = build.expression(
+        `
+        class Parent extends GrandParent {
+          @noop b = 'parent';
+        }
+        `,
+        { noop, GrandParent, ...runtime },
+      );
+
+      let Child = build.expression(
+        `
+        class Child extends Parent {
+          @noop c = 'child';
+        }
+        `,
+        { noop, Parent, ...runtime },
+      );
+
+      let child = new Child();
+      assert.strictEqual(child.a, 'grandparent');
+      assert.strictEqual(child.b, 'parent');
+      assert.strictEqual(child.c, 'child');
+    });
   });
 }
 fieldTests('old-build', oldBuild);


### PR DESCRIPTION
- Adds a reproduction test verifying decorated fields are properly inherited
- Fixes `findDeferredDecorator` 

While working on upgrading the `ember-decorators` family of packages. Migrating to V2 addon means `'@babel/plugin-proposal-decorators'` is no longer used.
This surfaced a decorator problem via  a test that checked whether `@attribute role = 'button';` applies for a child component as well.

A monkey-patched version can be viewed [BobrImperator/ember-decorators#1](https://github.com/BobrImperator/ember-decorators/pull/1) where the below test is passing. 
```js
  test('decorator does not add attribute to superclass', async function(assert) {
    class FooComponent extends Component {
      @attribute role = 'button';
    }

    class BarComponent extends FooComponent {
      @attribute id = 'bar';
    }

    this.owner.register('component:foo-component', FooComponent);
    this.owner.register('template:components/foo-component', precompileTemplate(`Hello, world!`, { strictMode: false }));

    this.owner.register('component:bar-component', BarComponent);
    this.owner.register('template:components/bar-component', precompileTemplate(`Hello, moon!`, { strictMode: false }));

    await render(precompileTemplate(`{{foo-component}}{{bar-component}}`, { strictMode: false }));

    assert.equal(findAll('[role="button"]').length, 2);
    assert.equal(findAll('#bar').length, 1);
  });
```